### PR TITLE
Change source url and libdb version

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,19 +1,28 @@
 FROM alpine:edge
 
 ENV gpp_version 6.4.0-r5
-ENV build_packages "git autoconf automake libtool g++=${gpp_version} make"
-ENV library_packages "boost-dev libressl-dev db-dev protobuf-dev libqrencode-dev libevent-dev"
+ENV build_packages "git curl autoconf automake libtool g++=${gpp_version} make"
+ENV library_packages "boost-dev libressl-dev protobuf-dev libqrencode-dev libevent-dev"
 ENV JOBS 4
 
 RUN apk --no-cache --update add --virtual .build ${build_packages} && \
 	apk --no-cache --update add ${library_packages} && \
+        curl -L http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz -o db-4.8.30.NC.tar.gz && \
+        tar zxvf db-4.8.30.NC.tar.gz && \
+        cd db-4.8.30.NC && \
+        cd build_unix && \
+        ../dist/configure --disable-shared --enable-cxx --disable-replication --with-pic --prefix=/usr/local/ && \
+        make libdb_cxx-4.8.a libdb-4.8.a && \
+        make install_lib install_include && \
+        cd ../.. && \
+        rm -rf db-4.8.30.NC && \
 	git clone -b z1.2.1 --depth 1 https://github.com/BitzenyCoreDevelopers/bitzeny.git && \
 	cd bitzeny && \
-  ./autogen.sh && \
+       ./autogen.sh && \
 	sed -e 's/wait $am_sleep/:/' configure > configure.new && \
 	chmod +x configure.new && \
-  ./configure.new --prefix=/usr --without-gui --disable-tests --with-incompatible-bdb --enable-hardening --without-miniupnpc && \
-  make --jobs="${JOBS}" && \
+        ./configure.new LDFLAGS=-L/usr/local/lib/ CPPFLAGS=-I/usr/local/include/ --prefix=/usr --without-gui --disable-tests --with-incompatible-bdb --enable-hardening --without-miniupnpc && \
+        make --jobs="${JOBS}" && \
 	make install && \
 	apk del --purge .build && \
 	cd / && \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -7,7 +7,7 @@ ENV JOBS 4
 
 RUN apk --no-cache --update add --virtual .build ${build_packages} && \
 	apk --no-cache --update add ${library_packages} && \
-	git clone -b z1.2.x --depth 1 https://github.com/onokatio/bitzeny && \
+	git clone -b z1.2.1 --depth 1 https://github.com/BitzenyCoreDevelopers/bitzeny.git && \
 	cd bitzeny && \
   ./autogen.sh && \
 	sed -e 's/wait $am_sleep/:/' configure > configure.new && \


### PR DESCRIPTION
I've updated bitzeny source repo/branch to z1.2.1@BitzenyCoreDevelopers:bitzeny as the former branch is no longer available.

Also I updated Dockerfile to use `libdb-4.8` built from source instead of apk's `db-dev` (=`libdb-5.3`) since the latest breaks backward compatibility so that possibly cause **IN**compatible `wallet.dat`. with original daemon (i.e., distributed at bitzeny.org).